### PR TITLE
Fix the offset calculation

### DIFF
--- a/src/main/java/com/cfelde/bohmap/BOHMap.java
+++ b/src/main/java/com/cfelde/bohmap/BOHMap.java
@@ -142,6 +142,10 @@ public class BOHMap implements Map<Binary, Binary> {
 		return address;
 	}
 
+	private long getPartitionOffset(byte[] keyData) {
+		return Math.abs(hashFunction.apply(keyData) % partitionCount);
+	}
+
 	@Override
 	public int size() {
 		if (itemCount > Integer.MAX_VALUE)
@@ -164,8 +168,7 @@ public class BOHMap implements Map<Binary, Binary> {
 		final byte[] keyData = bKey.getValue();
 		final int keySize = keyData.length;
 
-		final int hash = Math.abs(hashFunction.apply(keyData));
-		final long offset = hash % partitionCount;
+		final long offset = getPartitionOffset(keyData);
 
 		// This is the location of the partition on which the entry key belongs
 		long locationAddress = unsafe.getAddress(partitionAddress + (offset * addressSize));
@@ -288,8 +291,7 @@ public class BOHMap implements Map<Binary, Binary> {
 		final byte[] keyData = bKey.getValue();
 		final int keySize = keyData.length;
 
-		final int hash = Math.abs(hashFunction.apply(keyData));
-		final long offset = hash % partitionCount;
+		final long offset = getPartitionOffset(keyData);
 
 		// This is the location of the partition on which the entry key belongs
 		long locationAddress = unsafe.getAddress(partitionAddress + (offset * addressSize));
@@ -360,8 +362,7 @@ public class BOHMap implements Map<Binary, Binary> {
 		final byte[] keyData = key.getValue();
 		final int keySize = keyData.length;
 
-		final int hash = Math.abs(hashFunction.apply(keyData));
-		final long offset = hash % partitionCount;
+		final long offset = getPartitionOffset(keyData);
 
 		// This is the location of the partition on which the entry key belongs
 		long locationAddress = unsafe.getAddress(partitionAddress + (offset * addressSize));
@@ -507,8 +508,7 @@ public class BOHMap implements Map<Binary, Binary> {
 		final byte[] keyData = bKey.getValue();
 		final int keySize = keyData.length;
 
-		final int hash = Math.abs(hashFunction.apply(keyData));
-		final long offset = hash % partitionCount;
+		final long offset = getPartitionOffset(keyData);
 
 		// This is the location of the partition on which the entry key belongs
 		long locationAddress = unsafe.getAddress(partitionAddress + (offset * addressSize));

--- a/src/test/com/felde/bohmap/BOHMapTest.java
+++ b/src/test/com/felde/bohmap/BOHMapTest.java
@@ -1,0 +1,20 @@
+package com.cfelde.bohmap;
+
+import org.junit.Test;
+
+
+public class BOHMapTest {
+
+	@Test
+	public void testNegativeAbs() {
+		// Initialise a map with a hash function such that Math.abs would return a negative number.
+		BOHMap map = new BOHMap(100000, object -> Integer.MIN_VALUE);
+
+		Binary valueBinary = new Binary(new byte[] { 0, 0, 0, 0 });
+		Binary keyBinary = new Binary(new byte[] { 0, 0, 0, 0 });
+		map.put(keyBinary, valueBinary); // should not crash here
+
+		keyBinary = new Binary(new byte[] { 1, 0, 0, 0 });
+		map.put(keyBinary, valueBinary); // should not crash here
+	}
+}


### PR DESCRIPTION
To fix the SIGSEGV crash I had to extract the offset calculating function, and rearrange the division code so that the remainder would always be smaller than int max value. This allows to avoid that nasty case when Math.abs returns a negative value. 